### PR TITLE
Dockerfile: Don't hardcode the path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ LABEL "com.github.actions.description"="Run hlint on your haskell code base"
 LABEL "com.github.actions.icon"="upload-cloud"
 LABEL "com.github.actions.color"="6f42c1"
 
-CMD ["hlint", "/github/workspace"]
+CMD ["hlint", "."]


### PR DESCRIPTION
The GitHub Action framework will default to the correct default directory.